### PR TITLE
Add a public interface to load bindata fonts in addition to the built-in ones

### DIFF
--- a/fontmanager.go
+++ b/fontmanager.go
@@ -122,14 +122,26 @@ func (fm *fontManager) loadBuildInFont() error {
 		if err != nil {
 			return err
 		}
-		// Get the font
-		font, err := parseFontContent(string(fontStr))
+		// Load the font
+		err = fm.loadBinDataFont(string(fontStr), name)
 		if err != nil {
 			return err
 		}
-		// Register the font object in the fontLib
-		fm.fontLib[name] = font
 	}
+
+	return nil
+}
+
+// Load a bindata font
+func (fm *fontManager) loadBinDataFont(fontStr string, fontName string) error {
+
+	// Get the font
+	font, err := parseFontContent(fontStr)
+	if err != nil {
+		return err
+	}
+	// Register the font object in the fontLib
+	fm.fontLib[fontName] = font
 
 	return nil
 }

--- a/fontmanager.go
+++ b/fontmanager.go
@@ -123,7 +123,7 @@ func (fm *fontManager) loadBuildInFont() error {
 			return err
 		}
 		// Load the font
-		err = fm.loadBinDataFont(string(fontStr), name)
+		err = fm.loadBindataFont(fontStr, name)
 		if err != nil {
 			return err
 		}
@@ -133,10 +133,10 @@ func (fm *fontManager) loadBuildInFont() error {
 }
 
 // Load a bindata font
-func (fm *fontManager) loadBinDataFont(fontStr string, fontName string) error {
+func (fm *fontManager) loadBindataFont(fontBinary []byte, fontName string) error {
 
 	// Get the font
-	font, err := parseFontContent(fontStr)
+	font, err := parseFontContent(string(fontBinary))
 	if err != nil {
 		return err
 	}

--- a/render.go
+++ b/render.go
@@ -39,9 +39,9 @@ func (ar *AsciiRender) LoadFont(fontPath string) error {
 	return ar.fontMgr.loadFontList(fontPath)
 }
 
-// LoadBinDataFont loads provided bindata font string
-func (ar *AsciiRender) LoadBinDataFont(fontStr string, fontName string) error {
-	return ar.fontMgr.loadBinDataFont(fontStr, fontName)
+// LoadBinDataFont loads provided font binary
+func (ar *AsciiRender) LoadBindataFont(fontBinary []byte, fontName string) error {
+	return ar.fontMgr.loadBindataFont(fontBinary, fontName)
 }
 
 // Render renders a string with the default options

--- a/render.go
+++ b/render.go
@@ -39,6 +39,11 @@ func (ar *AsciiRender) LoadFont(fontPath string) error {
 	return ar.fontMgr.loadFontList(fontPath)
 }
 
+// LoadBinDataFont loads provided bindata font string
+func (ar *AsciiRender) LoadBinDataFont(fontStr string, fontName string) error {
+	return ar.fontMgr.loadBinDataFont(fontStr, fontName)
+}
+
 // Render renders a string with the default options
 // Calls the RenderOpts method with a new RenderOptions object
 func (ar *AsciiRender) Render(str string) (string, error) {


### PR DESCRIPTION
This library uses go-bindata for built-in fonts, but there is no way to load custom fonts the same way. This does not allow to use the library in my case.